### PR TITLE
Add Dockerfile and Docker Build Image workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,18 +1,43 @@
-name: Docker Image CI
+name: Build and publish Docker Image
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      packages: write
     steps:
-    - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag geospatial:0.8.0
+      # - uses: actions/checkout@v3
+      # - name: Build the Docker image
+      #   run: docker build . --file Dockerfile --tag geospatial:0.8.0
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,9 +17,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      # - uses: actions/checkout@v3
-      # - name: Build the Docker image
-      #   run: docker build . --file Dockerfile --tag geospatial:0.8.0
+      - name: Build the Docker image
+        uses: actions/checkout@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag geospatial:0.8.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM mambaorg/micromamba:1.4.2
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER binder/environment.yml /tmp/environment.yml
+
+RUN micromamba install -y -n base -f /tmp/environment.yml && \
+    micromamba clean --all --yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM mambaorg/micromamba:1.4.2
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER binder/environment.yml /tmp/environment.yml
 
-RUN micromamba install -y -n geo -f /tmp/environment.yml && \
+RUN micromamba install -y -n base -f /tmp/environment.yml && \
     micromamba clean --all --yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM mambaorg/micromamba:1.4.2
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER binder/environment.yml /tmp/environment.yml
 
-RUN micromamba install -y -n base -f /tmp/environment.yml && \
+RUN micromamba install -y -n geo -f /tmp/environment.yml && \
     micromamba clean --all --yes

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,5 +2,5 @@ name: geo
 channels:
   - conda-forge
 dependencies:
-  - geospatial:0.8.0
+  - geospatial=0.8.0
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,5 +2,5 @@ name: geo
 channels:
   - conda-forge
 dependencies:
-  - geospatial=0.8.0
+  - geospatial
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,5 +2,5 @@ name: geo
 channels:
   - conda-forge
 dependencies:
-  - geospatial
+  - geospatial:0.8.0
 


### PR DESCRIPTION
I added:
- `Dockerfile` to build `geospatial` Docker image currently based on `mambaorg/micromamba:1.4.2` docker image. The `Dockerfile` simply install `geospatial` metapackage.
- `docker-image.yml` file from Github Action Docker Image build workflow

Why I did it:
- I want to have a Docker image with every popular Python geospatial packages, so I can use it for my local development environment, instead of installing from conda everytime I start new project.

Proposal:
- Using Github or Docker Hub to host built Docker image
- dynamically configure built image version and base image version.

This is my first pull request, please give more advices so I can improve it.