### PR TITLE
Remove proplot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ panel
 palettable
 planetary-computer
 plotly
-proplot
+# proplot
 psycopg2
 pydeck
 pygis


### PR DESCRIPTION
proplot has not been updated for a year. It causes issues for conda-forge installation. Removing it from the list now. 