### PR TITLE
Make keplergl optional

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -24,10 +24,10 @@ jobs:
                   enable-cache: true
 
             - name: Set up Python ${{ matrix.python-version }}
-              run: uv python install ${{ matrix.python-version }}
+              run: uv venv --python ${{ matrix.python-version }}
 
             - name: Install dependencies
-              run: uv sync --python ${{ matrix.python-version }}
+              run: uv pip install .
 
             - name: Install optional dependencies
               run: |

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -21,7 +21,7 @@ jobs:
               uses: astral-sh/setup-uv@v5
               with:
                   version: "0.4.12"
-                  enable-cache: true
+                  enable-cache: false
 
             - name: Set up Python ${{ matrix.python-version }}
               run: uv venv --python ${{ matrix.python-version }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,10 +24,10 @@ jobs:
                   enable-cache: true
 
             - name: Set up Python ${{ matrix.python-version }}
-              run: uv python install ${{ matrix.python-version }}
+              run: uv venv --python ${{ matrix.python-version }}
 
             - name: Install dependencies
-              run: uv sync --python ${{ matrix.python-version }}
+              run: uv pip install .
 
             - name: Install optional dependencies
               run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
               uses: astral-sh/setup-uv@v5
               with:
                   version: "0.4.12"
-                  enable-cache: true
+                  enable-cache: false
 
             - name: Set up Python ${{ matrix.python-version }}
               run: uv venv --python ${{ matrix.python-version }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,7 @@ jobs:
               uses: astral-sh/setup-uv@v5
               with:
                   version: "0.4.12"
-                  enable-cache: true
+                  enable-cache: false
 
             - name: Set up Python ${{ matrix.config.py }}
               run: uv venv --python ${{ matrix.config.py }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,7 +31,7 @@ jobs:
               run: uv python install ${{ matrix.config.py }}
 
             - name: Install dependencies
-              run: uv sync --python ${{ matrix.config.py }}
+              run: uv pip install .
 
             - name: Test import
               run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,7 +28,7 @@ jobs:
                   enable-cache: true
 
             - name: Set up Python ${{ matrix.config.py }}
-              run: uv python install ${{ matrix.config.py }}
+              run: uv venv --python ${{ matrix.config.py }}
 
             - name: Install dependencies
               run: uv pip install .

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+                python-version: ["3.9", "3.10", "3.11", "3.12"]
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -22,7 +22,7 @@ jobs:
               uses: astral-sh/setup-uv@v5
               with:
                   version: "0.4.12"
-                  enable-cache: true
+                  enable-cache: false
 
             - name: Set up Python ${{ matrix.python-version }}
               run: uv venv --python ${{ matrix.python-version }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.9", "3.10", "3.11", "3.12"]
+                python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -28,7 +28,7 @@ jobs:
               run: uv python install ${{ matrix.python-version }}
 
             - name: Install dependencies
-              run: uv sync --python ${{ matrix.python-version }}
+              run: uv pip install .
 
             - name: Install optional dependencies
               run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
                   enable-cache: true
 
             - name: Set up Python ${{ matrix.python-version }}
-              run: uv python install ${{ matrix.python-version }}
+              run: uv venv --python ${{ matrix.python-version }}
 
             - name: Install dependencies
               run: uv pip install .

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,7 +27,7 @@ jobs:
               run: uv python install ${{ matrix.python-version }}
 
             - name: Install dependencies
-              run: uv sync --python ${{ matrix.python-version }}
+              run: uv pip install .
 
             - name: Test import
               run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
               uses: astral-sh/setup-uv@v5
               with:
                   version: "0.4.12"
-                  enable-cache: true
+                  enable-cache: false
 
             - name: Set up Python ${{ matrix.python-version }}
               run: uv venv --python ${{ matrix.python-version }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
                   enable-cache: true
 
             - name: Set up Python ${{ matrix.python-version }}
-              run: uv python install ${{ matrix.python-version }}
+              run: uv venv --python ${{ matrix.python-version }}
 
             - name: Install dependencies
               run: uv pip install .

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ hvplot
 hypercoast
 ipygany
 ipyleaflet
-keplergl
+# keplergl
 laspy
 leafmap>=0.38.0
 # lidar


### PR DESCRIPTION
The recent keplergl updates introduces the geoarrow-pyarrow and geoarrow-c dependencies, which causes issues for Windows. This PR makes keplergl optional. 

https://github.com/giswqs/geog-510/discussions/19